### PR TITLE
Add version 1.5.x  and some minor change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.1
+
+* Package Kubernetes v1.5.1 client binary.
+
+## 1.5.0
+
+* Package Kubernetes v1.5.0 client binary.
+
 ## 1.4.7
 
 * Package Kubernetes v1.4.7 client binary.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.5
 MAINTAINER Zappi DevOps <devops@zappistore.com>
 
 ARG BUILD_DEPS="ca-certificates wget"
-ARG KUBECTL_VERSION="v1.5.0"
+ARG KUBECTL_VERSION="v1.5.1"
 ARG KUBECTL_PACKAGE="kubernetes-client-linux-amd64.tar.gz"
-ARG KUBECTL_SHA="afae4fadb7bbb1532967f88fef1de6458abda17219f634cc2c41608fd83ae7f6"
+ARG KUBECTL_SHA="662fc57057290deb38ec49dd7daf4a4a5b91def2dbdb7ee7a4494dec611379a5"
 
 RUN apk update && \
     apk upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.5
 MAINTAINER Zappi DevOps <devops@zappistore.com>
 
 ARG BUILD_DEPS="ca-certificates wget"
-ARG KUBECTL_VERSION="v1.4.7"
+ARG KUBECTL_VERSION="v1.5.0"
 ARG KUBECTL_PACKAGE="kubernetes-client-linux-amd64.tar.gz"
-ARG KUBECTL_SHA="36232c9e21298f5f53dbf4851520a8cc53a2d6b6d2be8810cf5258a067570314"
+ARG KUBECTL_SHA="afae4fadb7bbb1532967f88fef1de6458abda17219f634cc2c41608fd83ae7f6"
 
 RUN apk update && \
     apk upgrade && \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Intellection Software Ltd
+Copyright (c) 2017 ZappiStore Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Allows us to tag for 1.5.0 (at f74cd23) and 1.5.1 (at 94c9625). Also makes sure that `latest` Docker image tag is the true "latest".