### PR TITLE
Fix permissions of the kubectl binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.3-1
+
+* Fix kubectl permissions.
+* Bump to Alpine 3.6.
+
 ## 1.5.3
 
 * Package Kubernetes v1.5.3 client binary.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 MAINTAINER Zappi DevOps <devops@zappistore.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk update && \
     echo "${KUBECTL_SHA} *${KUBECTL_PACKAGE}" | sha256sum -c - && \
     tar --no-same-owner -xzf ${KUBECTL_PACKAGE} && \
     mv /kubernetes/client/bin/kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /kubernetes*
 


### PR DESCRIPTION
Because the binary should be executable to everyone. Also took the opportunity to bump Alpine.